### PR TITLE
Prevent module from stepping on the rest of the msg object when reporting results

### DIFF
--- a/speedtest.js
+++ b/speedtest.js
@@ -12,9 +12,12 @@ module.exports = exports = function(RED) {
             var test = speedTest({ maxTime: config.maxTime });
 
             test.on('data', data => {
-                var reponse = Object.assign({}, data, { config: config });
+                var response = Object.assign({}, data, { config: config });
                 this.status({});
-                this.send({ payload: reponse });
+
+                msg.payload = response;
+
+                this.send(msg);
             });
 
             test.on('error', err => {


### PR DESCRIPTION
`this.send({ payload: reponse });` destroys any data currently residing in the `msg` object and creates a new object with just the payload.

For example, when workflow is initiated from slack information is stored on the msg object which is necessary to reply to the proper channel. This data should be preserved, with only the payload being set.